### PR TITLE
docs(server): document input contract; ensure eval() + no_grad for inference

### DIFF
--- a/server.py
+++ b/server.py
@@ -49,6 +49,7 @@ def setup(
     loaded_model = torch.hub.load(repo_or_dir, model_name, pretrained=pretrained).to(
         device
     )
+    loaded_model.eval()
 
     setup_kwargs = dict()
 
@@ -74,28 +75,24 @@ def process(
 ) -> numpy.ndarray:
     """Process a tensor of pixels using a given processor.
 
-    This function validates the input shape, pads the channel dimension if
-    necessary, converts the data to a PyTorch tensor, and runs it through
-    the provided processor on a CUDA device.
+    Input contract (caller side)
+    ----------------------------
+    pixels : NCZYX float32; H, W divisible by 14; Z=1.
+        Exactly 3 channels (RGB-like). Fewer channels are zero-padded to 3;
+        the caller is responsible for choosing which biological channels to
+        feed as R/G/B. For Cell Painting we use [AGP, DNA, ER].
+        Per-channel z-score normalize (subtract per-channel mean, divide by
+        per-channel std) before sending — DINOv2 was trained on standardized
+        inputs and expects this. Do NOT pass raw [0, 1] or [0, 255] pixels.
 
-    Parameters
-    ----------
-    pixels : numpy.ndarray
-        The input image data as a NumPy array. The expected shape is
-        (batch, channels, z, y, x).
-    processor : Callable
-        A PyTorch model or other callable that accepts a PyTorch tensor and
-        returns the processed result.
-    expected_tile_size : tuple[int]
-        A tuple representing the expected size of the last two dimensions (yx).
-    expected_channels : int
-        The number of channels the input tensor should have. If the input
-        `pixels` has fewer channels, it will be padded.
+    Server-side normalization (applied here)
+    ----------------------------------------
+    None — the backbone forward is called directly. Inference safety only
+    (``model.eval()`` + ``torch.no_grad()``) is set in ``setup``.
 
-    Returns
-    -------
-    numpy.ndarray
-        The result from the processor.
+    Output
+    ------
+    (N, 384) for vits14 — a single CLS-token embedding per tile.
     """
     input_channels = pixels.shape[2]
 
@@ -114,7 +111,8 @@ def process(
     torch_tensor = torch.from_numpy(pixels).float().cuda().to(device)
 
     print(f"Input shape {torch_tensor.shape}")
-    result = processor(torch_tensor)
+    with torch.no_grad():
+        result = processor(torch_tensor)
 
     return result
 


### PR DESCRIPTION
## Summary

Two small server-side hardenings shaken out while auditing DINOv2 preprocessing for a Cell Painting feature-extraction pipeline.

### 1. Document the input contract at `process()`

Replace the existing argument-style docstring with a concise contract block specifying:
- NCZYX float32, exactly 3 channels (RGB-like), H/W divisible by 14
- Caller is responsible for per-channel z-score before sending — DINOv2 was trained on standardized inputs; raw `[0, 1]` or `[0, 255]` pixels degrade the embedding measurably
- Server applies no additional normalization beyond inference-safety guards

### 2. Make eval-mode + no_grad explicit

`loaded_model.eval()` after `torch.hub.load` and `with torch.no_grad():` around the forward call. Both should be no-ops for our current usage (the backbone is in eval mode by default and we never call `.backward`), and indeed re-extracting 66 plates produced cosine 1.000 against the previous output — but relying on torch.hub defaults for inference-mode is fragile if a future hubconf change flips it. This makes the inference contract explicit.

## Test plan

- [x] 66-plate re-extraction reproduces previous output bit-for-bit (cos = 1.000, std ratio 1.00)
- [x] No change to GPU memory or throughput in observed runs